### PR TITLE
fix: Correct parameter order in PermissionDto constructor call

### DIFF
--- a/src/main/java/com/zl/mjga/service/UserRolePermissionService.java
+++ b/src/main/java/com/zl/mjga/service/UserRolePermissionService.java
@@ -149,7 +149,7 @@ public class UserRolePermissionService {
     }
     List<PermissionDto> permissionDtoList =
         permissionRecords.into(Permission.class).stream()
-            .map(pojo -> new PermissionDto(pojo.getId(), pojo.getName(), pojo.getCode()))
+            .map(pojo -> new PermissionDto(pojo.getId(), pojo.getCode(), pojo.getName()))
             .toList();
     return new PageResponseDto<>(
         permissionRecords.get(0).getValue("total_permission", Integer.class), permissionDtoList);


### PR DESCRIPTION
修正了 PermissionDto 构造函数调用时的参数顺序，确保 code 和 name 按照构造函数预期的 (id, code, name) 顺序传递 ; )